### PR TITLE
[TASK] Allow usage of illuminate v5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,30 +5,30 @@
 	"keywords": ["appengine", "datastore"],
 	"homepage": "http://pwhelan.github.io",
 	"license": "MIT",
-	
+
 	"authors": [
 		{
 			"name": "Phillip Whelan",
 			"email": "pwhelan@mixxx.org"
 		}
 	],
-	
+
 	"require": {
 		"php": ">=5.4.0",
-		"illuminate/support": "~4.2"
+		"illuminate/support": "~4.2|~5.1"
 	},
-	
+
 	"require-dev": {
 		"phpunit/phpunit": "4.4.*",
 		"slim/slim": "2.3.5",
 		"guzzlehttp/guzzle": "4.2",
 		"satooshi/php-coveralls": "dev-master"
 	},
-	
+
 	"autoload": {
 		"psr-4": {
 			"Datachore\\": "src/"
 		}
 	}
-	
+
 }


### PR DESCRIPTION
To be able to use the package in Laravel / Lumen v5.1 and up, the ``illuminate/support`` version requirement has to be raised.

Let's hear what Travis says :)